### PR TITLE
add missing generated CBLAS file in alien installation

### DIFF
--- a/src/modules/core/src/alien/kernels/simple_csr/CMakeLists.txt
+++ b/src/modules/core/src/alien/kernels/simple_csr/CMakeLists.txt
@@ -51,6 +51,9 @@ target_link_libraries(alien_kernel_simplecsr PUBLIC alien_utils)
 
 install(TARGETS alien_kernel_simplecsr EXPORT ${ALIEN_EXPORT_TARGET})
 
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/algebra/CBLAS.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/alien/kernels/simple_csr/algebra)
+
 if (ALIEN_MV_EXPR)
     target_compile_definitions(alien_kernel_simplecsr PUBLIC ALIEN_USE_EXPR)
 endif ()


### PR DESCRIPTION
add missing generated CBLAS file in alien installation required by other applications using alien