### PR TITLE
Change syntax for clang-format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,5 +1,9 @@
 name: Clang Format Checker
-on: [push]
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 jobs:
   clang-format-checking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should fix the blocked "expected".