### PR TITLE
Clone and redistribution for move API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+**News:**
+
+- \[move\]: add a `clone()` method to `MatrixData` and `VectorData`
+
 ## 1.1.3
 
 **News:**

--- a/src/core/alien/kernels/simple_csr/CSRStructInfo.h
+++ b/src/core/alien/kernels/simple_csr/CSRStructInfo.h
@@ -95,7 +95,10 @@ class CSRStructInfo
     return *this;
   }
 
-  CSRStructInfo* clone() const { return new CSRStructInfo(*this); }
+  CSRStructInfo* clone() const
+  {
+    return new CSRStructInfo(*this);
+  }
 
   void init(Arccore::Integer nrow)
   {
@@ -115,58 +118,115 @@ class CSRStructInfo
     m_cols.resize(nnz);
   }
 
-  Arccore::Int64 timestamp() const { return m_timestamp; }
+  Arccore::Int64 timestamp() const
+  {
+    return m_timestamp;
+  }
 
-  void setTimestamp(Arccore::Int64 value) { m_timestamp = value; }
+  void setTimestamp(Arccore::Int64 value)
+  {
+    m_timestamp = value;
+  }
 
-  bool getSymmetric() const { return m_symmetric; }
+  bool getSymmetric() const
+  {
+    return m_symmetric;
+  }
 
-  void setSymmetric(bool value) { m_symmetric = value; }
+  void setSymmetric(bool value)
+  {
+    m_symmetric = value;
+  }
 
-  Integer getNRows() const { return m_nrow; }
+  Integer getNRows() const
+  {
+    return m_nrow;
+  }
 
-  Integer getNRow() const { return m_nrow; }
+  Integer getNRow() const
+  {
+    return m_nrow;
+  }
 
   Arccore::UniqueArray<Arccore::Integer>& getBlockRowOffset()
   {
     return m_block_row_offset;
   }
 
-  Arccore::ArrayView<Integer> getRowOffset() { return m_row_offset.view(); }
+  Arccore::ArrayView<Integer> getRowOffset()
+  {
+    return m_row_offset.view();
+  }
 
   Arccore::ConstArrayView<Integer> getRowOffset() const
   {
     return m_row_offset.constView();
   }
 
-  const int* kcol() const { return m_row_offset.data(); }
+  const int* kcol() const
+  {
+    return m_row_offset.data();
+  }
 
-  int* kcol() { return m_row_offset.data(); }
+  int* kcol()
+  {
+    return m_row_offset.data();
+  }
 
   ConstArrayView<Integer> getBlockRowOffset() const
   {
     return m_block_row_offset.constView();
   }
 
-  UniqueArray<Integer>& getCols() { return m_cols; }
+  UniqueArray<Integer>& getCols()
+  {
+    return m_cols;
+  }
 
-  UniqueArray<Integer>& getBlockCols() { return m_block_cols; }
+  UniqueArray<Integer>& getBlockCols()
+  {
+    return m_block_cols;
+  }
 
-  ConstArrayView<Integer> getCols() const { return m_cols.constView(); }
+  ConstArrayView<Integer> getCols() const
+  {
+    return m_cols.constView();
+  }
 
-  int* cols() { return m_cols.data(); }
+  int* cols()
+  {
+    return m_cols.data();
+  }
 
-  const int* cols() const { return m_cols.data(); }
+  const int* cols() const
+  {
+    return m_cols.data();
+  }
 
-  ConstArrayView<Integer> getBlockCols() const { return m_block_cols.constView(); }
+  ConstArrayView<Integer> getBlockCols() const
+  {
+    return m_block_cols.constView();
+  }
 
-  ColOrdering& getColOrdering() { return m_col_ordering; }
+  ColOrdering& getColOrdering()
+  {
+    return m_col_ordering;
+  }
 
-  ColOrdering getColOrdering() const { return m_col_ordering; }
+  ColOrdering getColOrdering() const
+  {
+    return m_col_ordering;
+  }
 
-  void setDiagFirst(bool val) { m_diag_first = val; }
+  void setDiagFirst(bool val)
+  {
+    m_diag_first = val;
+  }
 
-  bool getDiagFirstOpt() const { return m_diag_first; }
+  bool getDiagFirstOpt() const
+  {
+    return m_diag_first;
+  }
 
   Integer getRowSize(Integer row) const
   {
@@ -178,11 +238,20 @@ class CSRStructInfo
     return m_block_row_offset[row + 1] - m_block_row_offset[row];
   }
 
-  Integer getNnz() const { return m_row_offset[m_nrow]; }
+  Integer getNnz() const
+  {
+    return m_row_offset[m_nrow];
+  }
 
-  Integer getNElems() const { return m_row_offset[m_nrow]; }
+  Integer getNElems() const
+  {
+    return m_row_offset[m_nrow];
+  }
 
-  Integer getBlockNnz() const { return m_block_row_offset[m_nrow]; }
+  Integer getBlockNnz() const
+  {
+    return m_block_row_offset[m_nrow];
+  }
 
   UniqueArray<Integer>& getUpperDiagOffset()
   {
@@ -210,9 +279,10 @@ class CSRStructInfo
 
   void allocate()
   {
-    m_cols.resize(m_row_offset[m_nrow]);
+    auto row_offset = (m_nrow > 0) ? m_row_offset[m_nrow] : 0;
+    m_cols.resize(row_offset);
     if (m_is_variable_block)
-      m_block_cols.resize(m_row_offset[m_nrow]);
+      m_block_cols.resize(row_offset);
   }
 
   void computeUpperDiagOffset() const

--- a/src/core/alien/kernels/simple_csr/SimpleCSRVector.h
+++ b/src/core/alien/kernels/simple_csr/SimpleCSRVector.h
@@ -109,8 +109,7 @@ class SimpleCSRVector : public IVectorImpl
   SimpleCSRVector& operator=(E const& expr);
 
   void init(const VectorDistribution& dist,
-            const bool need_allocate,
-            Integer ghost_size = 0)
+            const bool need_allocate) override
   {
     alien_debug([&] { cout() << "Initializing SimpleCSRVector " << this; });
     if (this->m_multi_impl) {
@@ -126,7 +125,7 @@ class SimpleCSRVector : public IVectorImpl
       m_local_size = m_own_distribution.localSize();
     }
     if (need_allocate) {
-      m_values.resize(m_local_size + ghost_size);
+      m_values.resize(m_local_size);
       m_values.fill(ValueT());
     }
   }
@@ -175,7 +174,7 @@ class SimpleCSRVector : public IVectorImpl
   SimpleCSRVector<ValueT>* cloneTo(const MultiVectorImpl* impl) const
   {
     SimpleCSRVector<ValueT>* vector = new SimpleCSRVector<ValueT>(impl);
-    vector->init(this->distribution(), false);
+    vector->init(this->distribution(), true);
     ConstArrayView<ValueType> thisValues = this->fullValues();
     vector->resize(thisValues.size());
     for (Integer i = 0; i < thisValues.size(); ++i)

--- a/src/movesemantic/CMakeLists.txt
+++ b/src/movesemantic/CMakeLists.txt
@@ -29,7 +29,7 @@ set(alien_semantic_public_header
         alien/move/data/MatrixData.h
         alien/move/data/VectorData.h
         alien/move/handlers/scalar/DoKDirectMatrixBuilder.h
-        )
+        alien/move/data/Redistribution.h)
 
 add_library(alien_semantic_move
         ${alien_semantic_public_header}
@@ -37,6 +37,7 @@ add_library(alien_semantic_move
         alien/move/data/MatrixData.cc
         alien/move/data/VectorData.cc
         alien/move/impl/MatrixMarketReader.cc
+        alien/move/data/Redistribution.cpp
         )
 
 if (ALIEN_GENERATE_DOCUMENTATION)

--- a/src/movesemantic/alien/move/data/MatrixData.cc
+++ b/src/movesemantic/alien/move/data/MatrixData.cc
@@ -85,9 +85,10 @@ MatrixData::MatrixData(MatrixData&& matrix)
 
 /*---------------------------------------------------------------------------*/
 
-void MatrixData::operator=(MatrixData&& matrix)
+MatrixData& MatrixData::operator=(MatrixData&& matrix)
 {
   m_impl = std::move(matrix.m_impl);
+  return *this;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -120,18 +121,6 @@ void MatrixData::setBlockInfos(const Integer block_size)
 {
   m_impl->setBlockInfos(block_size);
 }
-
-/*---------------------------------------------------------------------------*/
-
-/*
-  void
-  MatrixData::
-  setBlockInfos(const IBlockBuilder& builder)
-  {
-  std::unique_ptr<Block> block(new Block(m_impl->distribution(),
-  builder.blockSizes()));
-  m_impl->setBlockInfos(std::move(block));
-  }*/
 
 /*---------------------------------------------------------------------------*/
 
@@ -225,10 +214,7 @@ MatrixData::impl()
   if (!m_impl) {
     m_impl.reset(new MultiMatrixImpl());
   }
-  /* JMG ????
-     else if (!m_impl.unique()) { // Need to clone due to other references.
-     m_impl.reset(m_impl->clone());
-     } */
+
   return m_impl.get();
 }
 
@@ -238,6 +224,16 @@ const MultiMatrixImpl*
 MatrixData::impl() const
 {
   return m_impl.get();
+}
+
+/*---------------------------------------------------------------------------*/
+
+MatrixData
+MatrixData::clone() const
+{
+  MatrixData out;
+  out.m_impl.reset(m_impl->clone());
+  return out;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/movesemantic/alien/move/data/MatrixData.cc
+++ b/src/movesemantic/alien/move/data/MatrixData.cc
@@ -236,6 +236,13 @@ MatrixData::clone() const
   return out;
 }
 
+MatrixData createMatrixData(std::shared_ptr<MultiMatrixImpl> multi)
+{
+  MatrixData out;
+  out.m_impl = multi;
+  return out;
+}
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/src/movesemantic/alien/move/data/MatrixData.h
+++ b/src/movesemantic/alien/move/data/MatrixData.h
@@ -57,7 +57,6 @@ namespace Move
    public:
     typedef Real ValueType;
 
-   public:
     /*! @defgroup constructor Matrix Constructor
          * @{
          */
@@ -123,14 +122,14 @@ namespace Move
     /*! Destructor
          * All internal data structures will be deleted.
          */
-    virtual ~MatrixData() {}
+    virtual ~MatrixData() = default;
 
     /*! Move assignment
          * \brief Move from Matrix
          *
          * @param matrix Matrix to move from.
          */
-    void operator=(MatrixData&& matrix);
+    MatrixData& operator=(MatrixData&& matrix);
 
     /*! Initialize a Matrix with a Space.
          *
@@ -139,13 +138,13 @@ namespace Move
          */
     void init(const Space& space, const MatrixDistribution& dist);
 
-   private:
+    /*! Only support move semantic */
     MatrixData(const MatrixData&) = delete;
-
+    /*! Only support move semantic */
     void operator=(const MatrixData&) = delete;
 
-   public:
-   public:
+    MatrixData clone() const;
+
     /*! @defgroup block Block related API
          * @{ */
 
@@ -231,7 +230,6 @@ namespace Move
     bool isComposite() const;
     /* }@ */
 
-   public:
     /*! @defgroup impl Internal data structure access.
          *
          * Access multi-representation object.

--- a/src/movesemantic/alien/move/data/MatrixData.h
+++ b/src/movesemantic/alien/move/data/MatrixData.h
@@ -240,6 +240,8 @@ namespace Move
     const MultiMatrixImpl* impl() const;
     /*! } @ */
 
+    friend MatrixData createMatrixData(std::shared_ptr<MultiMatrixImpl> multi);
+
    private:
     std::shared_ptr<MultiMatrixImpl> m_impl;
   };
@@ -247,6 +249,7 @@ namespace Move
   MatrixData ALIEN_MOVESEMANTIC_EXPORT
   readFromMatrixMarket(Arccore::MessagePassing::IMessagePassingMng* pm, const std::string& filename);
 
+  MatrixData createMatrixData(std::shared_ptr<MultiMatrixImpl> multi);
 } // namespace Move
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/

--- a/src/movesemantic/alien/move/data/Redistribution.cpp
+++ b/src/movesemantic/alien/move/data/Redistribution.cpp
@@ -24,14 +24,22 @@
 
 namespace Alien::Move
 {
-MatrixData redistribute_matrix(Redistributor& redis, MatrixData&& src){
-  return std::move(src);
+MatrixData redistribute_matrix(Redistributor& redis, MatrixData&& src)
+{
+  auto multi = redis.redistribute(src.impl());
+  auto forgotten = std::move(src); // Take ownership of src
+  return createMatrixData(multi);
 }
 
-VectorData redistribute_vector(Redistributor& redis, VectorData&& src) {
+VectorData redistribute_vector(Redistributor& redis, VectorData&& src)
+{
+  auto multi = redis.redistribute(src.impl());
+  auto forgotten = std::move(src); // Take ownership of src
+  return createVectorData(multi);
+}
+
+VectorData redistribute_back_vector(Redistributor& redis, VectorData&& src)
+{
   return std::move(src);
 }
-VectorData redistribute_back_vector(Redistributor& redis, VectorData&& src) {
-  return std::move(src);
-}
-}
+} // namespace Alien::Move

--- a/src/movesemantic/alien/move/data/Redistribution.cpp
+++ b/src/movesemantic/alien/move/data/Redistribution.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 IFPEN-CEA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+//
+// Created by chevalierc on 23/02/22.
+//
+
+#include "Redistribution.h"
+
+namespace Alien::Move
+{
+MatrixData redistribute_matrix(Redistributor& redis, MatrixData&& src){
+  return std::move(src);
+}
+
+VectorData redistribute_vector(Redistributor& redis, VectorData&& src) {
+  return std::move(src);
+}
+VectorData redistribute_back_vector(Redistributor& redis, VectorData&& src) {
+  return std::move(src);
+}
+}

--- a/src/movesemantic/alien/move/data/Redistribution.h
+++ b/src/movesemantic/alien/move/data/Redistribution.h
@@ -30,13 +30,14 @@
 #include <alien/move/data/MatrixData.h>
 #include <alien/move/data/VectorData.h>
 
-namespace Alien::Move {
+namespace Alien::Move
+{
 
 ALIEN_MOVESEMANTIC_EXPORT MatrixData redistribute_matrix(Redistributor& redis, MatrixData&& src);
 
 ALIEN_MOVESEMANTIC_EXPORT VectorData redistribute_vector(Redistributor& redis, VectorData&& src);
 ALIEN_MOVESEMANTIC_EXPORT VectorData redistribute_back_vector(Redistributor& redis, VectorData&& src);
 
-}
+} // namespace Alien::Move
 
 #endif //ALIEN_REDISTRIBUTOR_H

--- a/src/movesemantic/alien/move/data/Redistribution.h
+++ b/src/movesemantic/alien/move/data/Redistribution.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 IFPEN-CEA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+//
+// Created by chevalierc on 23/02/22.
+//
+
+#ifndef ALIEN_REDISTRIBUTOR_H
+#define ALIEN_REDISTRIBUTOR_H
+
+#include <alien/move/AlienMoveSemanticExport.h>
+
+#include <alien/kernels/redistributor/Redistributor.h>
+
+#include <alien/move/data/MatrixData.h>
+#include <alien/move/data/VectorData.h>
+
+namespace Alien::Move {
+
+ALIEN_MOVESEMANTIC_EXPORT MatrixData redistribute_matrix(Redistributor& redis, MatrixData&& src);
+
+ALIEN_MOVESEMANTIC_EXPORT VectorData redistribute_vector(Redistributor& redis, VectorData&& src);
+ALIEN_MOVESEMANTIC_EXPORT VectorData redistribute_back_vector(Redistributor& redis, VectorData&& src);
+
+}
+
+#endif //ALIEN_REDISTRIBUTOR_H

--- a/src/movesemantic/alien/move/data/VectorData.cc
+++ b/src/movesemantic/alien/move/data/VectorData.cc
@@ -212,6 +212,13 @@ VectorData::clone() const
   out.m_impl.reset(m_impl->clone());
   return out;
 }
+
+VectorData createVectorData(std::shared_ptr<MultiVectorImpl> multi)
+{
+  VectorData out;
+  out.m_impl = multi;
+  return out;
+}
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/src/movesemantic/alien/move/data/VectorData.cc
+++ b/src/movesemantic/alien/move/data/VectorData.cc
@@ -65,13 +65,10 @@ VectorData::VectorData(VectorData&& vector)
 
 /*---------------------------------------------------------------------------*/
 
-VectorData::~VectorData() {}
-
-/*---------------------------------------------------------------------------*/
-
-void VectorData::operator=(VectorData&& vector)
+VectorData& VectorData::operator=(VectorData&& vector)
 {
   m_impl = std::move(vector.m_impl);
+  return *this;
 }
 
 /*---------------------------------------------------------------------------*/
@@ -206,6 +203,15 @@ VectorData::impl() const
   return m_impl.get();
 }
 
+/*---------------------------------------------------------------------------*/
+
+VectorData
+VectorData::clone() const
+{
+  VectorData out;
+  out.m_impl.reset(m_impl->clone());
+  return out;
+}
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 

--- a/src/movesemantic/alien/move/data/VectorData.h
+++ b/src/movesemantic/alien/move/data/VectorData.h
@@ -186,6 +186,8 @@ namespace Move
     const MultiVectorImpl* impl() const;
     /*! }@ */
 
+    friend VectorData createVectorData(std::shared_ptr<MultiVectorImpl> multi);
+
    private:
     std::shared_ptr<MultiVectorImpl> m_impl;
   };
@@ -193,6 +195,8 @@ namespace Move
   VectorData ALIEN_MOVESEMANTIC_EXPORT
   readFromMatrixMarket(const VectorDistribution& distribution, const std::string& filename);
 
+  // Do not export this factory.
+  VectorData createVectorData(std::shared_ptr<MultiVectorImpl> multi);
 } // namespace Move
 
 /*---------------------------------------------------------------------------*/

--- a/src/movesemantic/alien/move/data/VectorData.h
+++ b/src/movesemantic/alien/move/data/VectorData.h
@@ -49,7 +49,6 @@ namespace Move
    public:
     typedef Real ValueType;
 
-   public:
     /*! @defgroup constructor Vector Constructor
          * @{
          */
@@ -88,7 +87,7 @@ namespace Move
            * \param dist Parallel distribution.
            *
            * This vector is directly ready to use. */
-    VectorData(const VectorDistribution& dist);
+    explicit VectorData(const VectorDistribution& dist);
 
     /*! Move constructor for Vector
          *
@@ -100,14 +99,14 @@ namespace Move
     /*! Destructor
          * All internal data structures will be deleted.
          */
-    virtual ~VectorData();
+    virtual ~VectorData() = default;
 
     /*! Move assignment
          * \brief Move from Vector
          *
          * @param matrix Vector to move from.
          */
-    void operator=(VectorData&& vector);
+    VectorData& operator=(VectorData&& vector);
 
     /*! Initialize a Vector with a Space.
          *
@@ -116,16 +115,17 @@ namespace Move
          */
     void init(const ISpace& space, const VectorDistribution& dist);
 
+    /*! Only support move semantic */
     VectorData(const VectorData&) = delete;
+    /*! Only support move semantic */
+    VectorData& operator=(const VectorData&) = delete;
 
-    void operator=(const VectorData&) = delete;
+    VectorData clone() const;
 
-   public:
     /*! @defgroup block Block related API
          * @{ */
     void setBlockInfos(const Integer block_size);
 
-    // void setBlockInfos(const IBlockBuilder& block_size);
     void setBlockInfos(const Block* block);
 
     void setBlockInfos(const VBlock* block);
@@ -176,7 +176,6 @@ namespace Move
     bool hasUserFeature(String feature) const;
     /*! }@ */
 
-   public:
     /*! @defgroup impl Internal data structure access.
          *
          * Access multi-representation object.

--- a/src/movesemantic/tests/CMakeLists.txt
+++ b/src/movesemantic/tests/CMakeLists.txt
@@ -22,6 +22,8 @@ configure_file(simple_rhs.mtx simple_rhs.mtx COPYONLY)
 
 add_executable(move.gtest.mpi
         main.cpp
+        TestMatrix.cc
+        TestVector.cc
         TestIndexManager.cc
         TestDoKMatrix.cc
         TestDoKDirectMatrixBuilder.cc
@@ -29,7 +31,6 @@ add_executable(move.gtest.mpi
         )
 
 add_executable(move.gtest.seq main.cpp
-        TestVector.cc
         TestVectorBuilder.cc
         TestMatrixDirectBuilder.cc
         )

--- a/src/movesemantic/tests/TestMatrix.cc
+++ b/src/movesemantic/tests/TestMatrix.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 IFPEN-CEA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <alien/data/Space.h>
+#include <alien/distribution/MatrixDistribution.h>
+#include <alien/move/data/MatrixData.h>
+
+#include <Environment.h>
+
+// Tests the default c'tor.
+TEST(TestMatrix, DefaultConstructor)
+{
+  const Alien::Move::MatrixData m;
+  ASSERT_EQ(0, m.colSpace().size());
+  ASSERT_EQ(0, m.rowSpace().size());
+}
+
+// Tests the space c'tor.
+TEST(TestMatrix, SpaceConstructor)
+{
+  const Alien::Space row_space(9, "MyRowSpace");
+  const Alien::Space col_space(11, "MyColSpace");
+  const Alien::MatrixDistribution d(row_space, col_space, AlienTest::Environment::parallelMng());
+  const Alien::Move::MatrixData m(d);
+  ASSERT_TRUE(row_space == m.rowSpace());
+  ASSERT_TRUE(col_space == m.colSpace());
+  ASSERT_EQ(9, m.rowSpace().size());
+  ASSERT_EQ(11, m.colSpace().size());
+}
+
+// Tests the anonymous c'tor.
+TEST(TestMatrix, AnonymousConstructor)
+{
+  const Alien::MatrixDistribution d(10, 10, AlienTest::Environment::parallelMng());
+  const Alien::Move::MatrixData m(d);
+  ASSERT_TRUE(Alien::Space(10) == m.rowSpace());
+  ASSERT_TRUE(Alien::Space(10) == m.colSpace());
+}
+
+// Tests the rvalue c'tor.
+TEST(TestMatrix, RValueConstructor)
+{
+  const Alien::MatrixDistribution d(10, 10, AlienTest::Environment::parallelMng());
+  const auto m = Alien::Move::MatrixData(d);
+  ASSERT_TRUE(Alien::Space(10) == m.colSpace());
+}
+
+// Tests cloning Matrix
+TEST(TestMatrix, Clone)
+{
+  const Alien::MatrixDistribution d(10, 10, AlienTest::Environment::parallelMng());
+  auto m = Alien::Move::MatrixData(d);
+  auto m2 = m.clone();
+  ASSERT_EQ(10, m2.colSpace().size());
+  // Moving out m
+  auto m3 = std::move(m);
+  ASSERT_EQ(10, m2.rowSpace().size());
+}
+
+// Tests replacement
+TEST(TestMatrix, Replacement)
+{
+  const Alien::MatrixDistribution d10(10, 10, AlienTest::Environment::parallelMng());
+  auto v = Alien::Move::MatrixData(d10);
+  const Alien::MatrixDistribution d5(5, 10, AlienTest::Environment::parallelMng());
+  v = Alien::Move::MatrixData(d5);
+  ASSERT_TRUE(Alien::Space(5) == v.rowSpace());
+  ASSERT_TRUE(Alien::Space(10) == v.colSpace());
+}
+
+// Tests replacement
+TEST(TestMatrix, RValueAffectation)
+{
+  const Alien::MatrixDistribution d10(10, 10, AlienTest::Environment::parallelMng());
+  auto v = Alien::Move::MatrixData(d10);
+  const Alien::MatrixDistribution d5(5, 10, AlienTest::Environment::parallelMng());
+  auto v2 = Alien::Move::MatrixData(d5);
+  v = std::move(v2);
+  ASSERT_TRUE(Alien::Space(5) == v.rowSpace());
+}

--- a/src/movesemantic/tests/TestVector.cc
+++ b/src/movesemantic/tests/TestVector.cc
@@ -55,9 +55,21 @@ TEST(TestVector, AnonymousConstructor)
 TEST(TestVector, RValueConstructor)
 {
   const Alien::VectorDistribution d(10, AlienTest::Environment::parallelMng());
-  const Alien::Move::VectorData v = Alien::Move::VectorData(d);
+  const auto v = Alien::Move::VectorData(d);
   ASSERT_TRUE(Alien::Space(10) == v.space());
   ASSERT_EQ(10, v.space().size());
+}
+
+// Tests cloning vector
+TEST(TestVector, Clone)
+{
+  const Alien::VectorDistribution d(10, AlienTest::Environment::parallelMng());
+  auto v = Alien::Move::VectorData(d);
+  auto v2 = v.clone();
+  ASSERT_EQ(10, v2.space().size());
+  // Moving out v
+  auto v3 = std::move(v);
+  ASSERT_EQ(10, v2.space().size());
 }
 
 // Tests replacement


### PR DESCRIPTION
- Adding `clone()` method for `MatrixData` and `VectorData`
- Adding functions to redistribute matrices and vectors, from `move` API