### PR TITLE
Improve DoK performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 **News:**
 
 - \[move\]: add a `clone()` method to `MatrixData` and `VectorData`
+- \[core\]: dramatic improvement of `DoK` performance
 
 ## 1.1.3
 

--- a/src/core/alien/kernels/dok/DoKLocalMatrixIndexer.cc
+++ b/src/core/alien/kernels/dok/DoKLocalMatrixIndexer.cc
@@ -55,12 +55,12 @@ DoKLocalMatrixIndexer::Offset
 DoKLocalMatrixIndexer::create(
 Integer i, Integer j, DoKLocalMatrixIndexer::Offset& tentative_offset)
 {
-  auto o = find(i, j);
-  auto offset = o.value_or(tentative_offset);
-  if (!o.has_value()) {
-    associate(i, j, tentative_offset++);
+  auto to_insert = std::make_pair<Key, Offset>(Key(i, j), tentative_offset++);
+  auto [index, is_inserted] = m_data.insert(to_insert);
+  if (!is_inserted) {
+    tentative_offset--;
   }
-  return offset;
+  return index->second;
 }
 
 ILocalMatrixIndexer*


### PR DESCRIPTION
- Avoid unneeded (i.e. already performed) computations
- Better use of `std::unordered_map`: we directly insert value instead of dealing with thrown exceptions