### PR TITLE
Improving CSR redistributor

### DIFF
--- a/src/core/alien/kernels/simple_csr/redistribution/SimpleCSRDistributor.h
+++ b/src/core/alien/kernels/simple_csr/redistribution/SimpleCSRDistributor.h
@@ -49,13 +49,13 @@ class ALIEN_EXPORT SimpleCSRDistributor
 
  private:
   template <typename T>
-  T _owner(const std::vector<T>& offset, T global_row_id);
+  std::optional<T> _owner(const std::vector<T>& offset, T global_row_id);
   template <typename T>
   void _distribute(const int bb, const T* src, T* dst);
   template <typename T>
   void _resizeBuffers(const int bb);
   void _finishExchange();
-  int _dstMe(int) const;
+  std::optional<int> _dstMe(int) const;
 
   struct CommInfo
   {


### PR DESCRIPTION
- Use `std::optional` instead of magic value
- Avoid `sizeof()` constructions