### PR TITLE
Matrix market reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,6 @@ list(APPEND CMAKE_MODULE_PATH ${ARCCON_MODULE_PATH})
 
 find_package(Arccore REQUIRED)
 
-find_package(LibArchive REQUIRED)
-
 include(GNUInstallDirs)
 
 if (ALIEN_DEFAULT_OPTIONS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ list(APPEND CMAKE_MODULE_PATH ${ARCCON_MODULE_PATH})
 
 find_package(Arccore REQUIRED)
 
+find_package(LibArchive REQUIRED)
+
 include(GNUInstallDirs)
 
 if (ALIEN_DEFAULT_OPTIONS)

--- a/src/refsemantic/CMakeLists.txt
+++ b/src/refsemantic/CMakeLists.txt
@@ -51,6 +51,7 @@ set(alien_refsemantic_public_header
         alien/ref/import_export/SystemReader.h
         alien/ref/import_export/SystemWriter.h
         alien/ref/import_export/MatrixMarketSystemWriter.h
+        alien/ref/import_export/MatrixMarketSystemReader.h
         alien/ref/import_export/HDF5Tools.h)
     
 add_library(alien_semantic_ref
@@ -99,6 +100,8 @@ add_library(alien_semantic_ref
         alien/ref/handlers/scalar/VectorWriter.h
         alien/ref/import_export/MatrixMarketSystemWriter.cc
         alien/ref/import_export/MatrixMarketSystemWriter.h
+        alien/ref/import_export/MatrixMarketSystemReader.cc
+        alien/ref/import_export/MatrixMarketSystemReader.h
         alien/ref/import_export/SystemInfo.h
         alien/ref/import_export/SystemReader.cc
         alien/ref/import_export/SystemReader.h

--- a/src/refsemantic/CMakeLists.txt
+++ b/src/refsemantic/CMakeLists.txt
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+find_package(LibArchive)
 
 set(alien_refsemantic_public_header
         alien/ref/AlienImportExport.h
@@ -52,10 +53,9 @@ set(alien_refsemantic_public_header
         alien/ref/import_export/SystemWriter.h
         alien/ref/import_export/MatrixMarketSystemWriter.h
         alien/ref/import_export/MatrixMarketSystemReader.h
-        alien/ref/import_export/SuiteSparseArchiveSystemReader.h
         alien/ref/import_export/HDF5Tools.h)
-    
-add_library(alien_semantic_ref
+
+set(alien_semantic_ref_list
         alien/ref/AlienImportExport.h
         alien/ref/AlienRefSemantic.h
         alien/ref/AlienRefSemanticPrecomp.h
@@ -103,14 +103,23 @@ add_library(alien_semantic_ref
         alien/ref/import_export/MatrixMarketSystemWriter.h
         alien/ref/import_export/MatrixMarketSystemReader.cc
         alien/ref/import_export/MatrixMarketSystemReader.h
-        alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
-        alien/ref/import_export/SuiteSparseArchiveSystemReader.h
         alien/ref/import_export/SystemInfo.h
         alien/ref/import_export/SystemReader.cc
         alien/ref/import_export/SystemReader.h
         alien/ref/import_export/SystemWriter.cc
         alien/ref/import_export/SystemWriter.h
         alien/ref/import_export/HDF5Tools.h)
+
+if (LibArchive_FOUND)
+   list(APPEND alien_semantic_ref_list
+           alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
+           alien/ref/import_export/SuiteSparseArchiveSystemReader.h)
+   list(APPEND alien_refsemantic_public_header
+           alien/ref/import_export/SuiteSparseArchiveSystemReader.h)
+   add_definitions(-DALIEN_USE_LIBARCHIVE)
+endif ()
+
+add_library(alien_semantic_ref ${alien_semantic_ref_list})
 
 if (ALIEN_GENERATE_DOCUMENTATION)
     set(DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
@@ -138,7 +147,10 @@ target_sources(alien_semantic_ref PRIVATE
               )
 
 target_link_libraries(alien_semantic_ref PUBLIC alien_core)
-target_link_libraries(alien_semantic_ref PUBLIC archive)
+
+if(LibArchive_FOUND)
+    target_link_libraries(alien_semantic_ref PUBLIC archive)
+endif ()
 
 target_include_directories(alien_semantic_ref PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/src/refsemantic/CMakeLists.txt
+++ b/src/refsemantic/CMakeLists.txt
@@ -52,6 +52,7 @@ set(alien_refsemantic_public_header
         alien/ref/import_export/SystemWriter.h
         alien/ref/import_export/MatrixMarketSystemWriter.h
         alien/ref/import_export/MatrixMarketSystemReader.h
+        alien/ref/import_export/SuiteSparseArchiveSystemReader.h
         alien/ref/import_export/HDF5Tools.h)
     
 add_library(alien_semantic_ref
@@ -102,6 +103,8 @@ add_library(alien_semantic_ref
         alien/ref/import_export/MatrixMarketSystemWriter.h
         alien/ref/import_export/MatrixMarketSystemReader.cc
         alien/ref/import_export/MatrixMarketSystemReader.h
+        alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
+        alien/ref/import_export/SuiteSparseArchiveSystemReader.h
         alien/ref/import_export/SystemInfo.h
         alien/ref/import_export/SystemReader.cc
         alien/ref/import_export/SystemReader.h
@@ -135,6 +138,7 @@ target_sources(alien_semantic_ref PRIVATE
               )
 
 target_link_libraries(alien_semantic_ref PUBLIC alien_core)
+target_link_libraries(alien_semantic_ref PUBLIC archive)
 
 target_include_directories(alien_semantic_ref PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/src/refsemantic/alien/ref/AlienImportExport.h
+++ b/src/refsemantic/alien/ref/AlienImportExport.h
@@ -25,3 +25,4 @@
 #include <alien/ref/import_export/SystemWriter.h>
 
 #include <alien/ref/import_export/MatrixMarketSystemReader.h>
+#include <alien/ref/import_export/SuiteSparseArchiveSystemReader.h>

--- a/src/refsemantic/alien/ref/AlienImportExport.h
+++ b/src/refsemantic/alien/ref/AlienImportExport.h
@@ -25,4 +25,6 @@
 #include <alien/ref/import_export/SystemWriter.h>
 
 #include <alien/ref/import_export/MatrixMarketSystemReader.h>
+#ifdef ALIEN_USE_LIBARCHIVE
 #include <alien/ref/import_export/SuiteSparseArchiveSystemReader.h>
+#endif

--- a/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
+++ b/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
@@ -213,6 +213,11 @@ void loadMMRhsFromReader(Vector& rhs,ReaderT& reader)
     throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
   }
 
+  if(m > 1) // does not allow more than one vector
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"More than one vector not allowed");
+  }
+
   rhs = Vector(n,n,nullptr);
 
   VectorWriter vector_writer(rhs);

--- a/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
+++ b/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
@@ -17,223 +17,10 @@
  */
 
 #include <alien/ref/import_export/MatrixMarketSystemReader.h>
-#include <alien/ref/handlers/scalar/DirectMatrixBuilder.h>
-#include <alien/ref/handlers/scalar/VectorWriter.h>
-
-#include <alien/ref/data/scalar/Matrix.h>
-#include <alien/ref/data/scalar/Vector.h>
-
-#include <string>
-#include <fstream>
-
-#include <cstdio>
+#include <alien/ref/import_export/Reader.h>
 
 namespace Alien
 {
-
-class FStreamReader
-{
-private:
-  std::fstream *m_file_stream = nullptr;
-  std::string m_line;
-
-public:
-  FStreamReader() = delete;
-  FStreamReader(const FStreamReader&) = delete;
-  FStreamReader& operator=(const FStreamReader&) = delete;
-
-  FStreamReader(std::fstream* fdes)
-    :
-    m_file_stream(fdes)
-  {}
-
-  const char* line()
-  {
-    std::getline(*m_file_stream,m_line);
-
-    return m_line.c_str();
-  }
-
-  const char* currentLine() const
-  {
-    return m_line.c_str();
-  }
-};
-
-#if 0
-class LibArchiveReader
-{
-private:
-  const int m_buffer_size = 1024;
-
-  archive* m_archive = nullptr;
-  std::string m_line;
-  std::vector<char> m_buffer;
-  std::size_t m_pos = 0;
-
-public:
-  LibArchiveReader() = delete;
-  LibArchiveReader(const LibArchiveReader&) = delete;
-  LibArchiveReader& operator=(const LibArchiveReader&) = delete;
-
-  LibArchiveReader(archive *archive)
-    :
-    m_archive(archive),
-    m_buffer(m_buffer_size,0)
-  {
-    m_line.reserve(m_buffer_size);
-  }
-
-  const char* line()
-  {
-    la_ssize_t r = 1;
-
-    m_line.resize(0);
-
-    if(m_pos == 0)
-    {
-      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
-    }
-
-    while(r > 0)
-    {
-      for(auto i = m_pos;i < m_buffer_size;++i)
-      {
-        m_line.push_back(m_buffer[i]);
-        if(m_buffer[i] == '\n')
-        {
-          m_pos = i + 1;
-          //std::cout << m_line;
-          return m_line.c_str();
-        }
-      }
-      // end of line is not found so read next buffer;
-      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
-      m_pos = 0;
-    }
-
-    // end of file reached
-    return m_line.c_str();
-  }
-
-  const char* currentLine() const
-  {
-    return m_line.c_str();
-  }
-};
-#endif
-
-template<typename ReaderT>
-bool readMMHeaderFromReader(const std::string& mm_type,ReaderT& reader)
-{
-  // check header
-  char param1[32];
-  char param2[32];
-  char param3[32];
-  char param4[32];
-
-  // TODO: use methods that directly read from std::string
-  if(sscanf(reader.line(),"%%%%MatrixMarket %31s %31s %31s %31s"
-    ,param1
-    ,param2
-    ,param3
-    ,param4)!=4)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header");
-  }
-  if(std::string(param1)!=std::string("matrix"))
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 1");
-  }
-  if(std::string(param2) != mm_type)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 2");
-  }
-  if(std::string(param3) != std::string("real"))
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 3");
-  }
-
-  // skip comments
-  while(reader.line()[0]=='%');
-
-  return std::string(param4)==std::string("symmetric");
-}
-
-template<typename ReaderT>
-void loadMMMatrixFromReader(Matrix& A,ReaderT& reader)
-{
-  bool is_symmetric = readMMHeaderFromReader("coordinate",reader);
-
-  // first non comment line is: n m nnz
-  int n,m,nnz;
-  if(sscanf(reader.currentLine(),"%d %d %d",&n,&m,&nnz) != 3)
-  {
-    perror("read mtx size line");
-    throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
-  }
-
-
-  A = Matrix(n, m, n, nullptr);
-
-  DirectMatrixOptions::SymmetricFlag sym_flag = is_symmetric ?
-    DirectMatrixOptions::eSymmetric : DirectMatrixOptions::eUnSymmetric;
-
-  DirectMatrixBuilder matrix_builder(A,DirectMatrixOptions::eResetAllocation,sym_flag);
-  matrix_builder.allocate();
-
-  for(int i=0;i<nnz;++i)
-  {
-    int li = 0;
-    int ci = 0;
-    double val = 0;
-
-    if(sscanf(reader.line(),"%d %d %lg\n",&li,&ci,&val) != 3)
-    {
-      perror("read mtx line");
-      throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
-    }
-    li--;
-    ci--;
-
-    matrix_builder.addData(li,ci,val);
-  }
-}
-
-template<typename ReaderT>
-void loadMMRhsFromReader(Vector& rhs,ReaderT& reader)
-{
-  readMMHeaderFromReader("array",reader);
-
-  // first non comment line is: n m
-  int n,m;
-  if(sscanf(reader.currentLine(),"%d %d",&n,&m) != 2)
-  {
-    perror("read mtx size line");
-    throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
-  }
-
-  if(m > 1) // does not allow more than one vector
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"More than one vector not allowed");
-  }
-
-  rhs = Vector(n,n,nullptr);
-
-  VectorWriter vector_writer(rhs);
-
-  for(int i = 0;i < n;++i)
-  {
-    double val = 0;
-    if(sscanf(reader.line(),"%lg\n",&val) != 1)
-    {
-      perror("read mtx line");
-      throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
-    }
-
-    vector_writer[i] = val;
-  }
-}
 
 MatrixMarketSystemReader::MatrixMarketSystemReader(std::string const& filename)
 : m_filename(filename)
@@ -244,28 +31,26 @@ MatrixMarketSystemReader::~MatrixMarketSystemReader() = default;
 
 void MatrixMarketSystemReader::read(Matrix& A)
 {
-  std::fstream file_stream(m_filename,std::ios::in);
+  std::fstream file_stream(m_filename, std::ios::in);
 
-  if(!file_stream.good())
-  {
+  if (!file_stream.good()) {
     throw FatalErrorException(__PRETTY_FUNCTION__);
   }
 
   FStreamReader reader(&file_stream);
-  loadMMMatrixFromReader<FStreamReader>(A,reader);
+  loadMMMatrixFromReader<FStreamReader>(A, reader);
 }
 
 void MatrixMarketSystemReader::read(Vector& rhs)
 {
-  std::fstream file_stream(m_filename,std::ios::in);
+  std::fstream file_stream(m_filename, std::ios::in);
 
-  if(!file_stream.good())
-  {
+  if (!file_stream.good()) {
     throw FatalErrorException(__PRETTY_FUNCTION__);
   }
 
   FStreamReader reader(&file_stream);
-  loadMMRhsFromReader<FStreamReader>(rhs,reader);
+  loadMMRhsFromReader<FStreamReader>(rhs, reader);
 }
 
 } /* namespace Alien */

--- a/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
+++ b/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.cc
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 IFPEN-CEA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <alien/ref/import_export/MatrixMarketSystemReader.h>
+#include <alien/ref/handlers/scalar/DirectMatrixBuilder.h>
+#include <alien/ref/handlers/scalar/VectorWriter.h>
+#include <string>
+
+#include <alien/ref/data/scalar/Matrix.h>
+#include <alien/ref/data/scalar/Vector.h>
+
+#include <cstdio>
+
+namespace Alien
+{
+
+class StreamFILEReader
+{
+ private:
+  FILE* m_fdes = nullptr;
+  std::string m_line;
+
+ public:
+  StreamFILEReader() = delete;
+  StreamFILEReader(const StreamFILEReader&) = delete;
+  StreamFILEReader& operator=(const StreamFILEReader&) = delete;
+
+  explicit StreamFILEReader(FILE* fdes)
+  : m_fdes(fdes)
+  {}
+
+  const char* line()
+  {
+    char* line = nullptr;
+    std::size_t size = 0;
+    getline(&line, &size, m_fdes);
+    // TODO: find a way to directly read in m_line and avoid next copy
+    m_line = line;
+    std::free(line);
+
+    return m_line.c_str();
+  }
+
+  [[nodiscard]] const char* currentLine() const
+  {
+    return m_line.c_str();
+  }
+};
+
+template<typename ReaderT>
+bool readMMHeaderFromReader(const std::string& mm_type,ReaderT& reader)
+{
+  // check header
+  char param1[32];
+  char param2[32];
+  char param3[32];
+  char param4[32];
+
+  // TODO: use methods that directly read from std::string
+  if(sscanf(reader.line(),"%%%%MatrixMarket %31s %31s %31s %31s"
+    ,param1
+    ,param2
+    ,param3
+    ,param4)!=4)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header");
+  }
+  if(std::string(param1)!=std::string("matrix"))
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 1");
+  }
+  if(std::string(param2) != mm_type)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 2");
+  }
+  if(std::string(param3) != std::string("real"))
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix market wrong header 3");
+  }
+
+  // skip comments
+  while(reader.line()[0]=='%');
+
+  return std::string(param4)==std::string("symmetric");
+}
+
+template<typename ReaderT>
+void loadMMMatrixFromReader(Matrix& A,ReaderT& reader)
+{
+  bool is_symmetric = readMMHeaderFromReader("coordinate",reader);
+
+  // first non comment line is: n m nnz
+  int n,m,nnz;
+  if(sscanf(reader.currentLine(),"%d %d %d",&n,&m,&nnz) != 3)
+  {
+    perror("read mtx size line");
+    throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
+  }
+
+
+  A = Matrix(n, m, n, nullptr);
+
+  DirectMatrixOptions::SymmetricFlag sym_flag = is_symmetric ?
+    DirectMatrixOptions::eSymmetric : DirectMatrixOptions::eUnSymmetric;
+
+  DirectMatrixBuilder matrix_builder(A,DirectMatrixOptions::eResetAllocation,sym_flag);
+
+  for(int i=0;i<nnz;++i)
+  {
+    int li = 0;
+    int ci = 0;
+    double val = 0;
+
+    if(sscanf(reader.line(),"%d %d %lg\n",&li,&ci,&val) != 3)
+    {
+      perror("read mtx line");
+      throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
+    }
+    li--;
+    ci--;
+
+    matrix_builder.addData(li,ci,val);
+  }
+}
+
+template<typename ReaderT>
+void loadMMRhsFromReader(Vector& rhs,ReaderT& reader)
+{
+  readMMHeaderFromReader("array",reader);
+
+  // first non comment line is: n m
+  int n,m;
+  if(sscanf(reader.currentLine(),"%d %d",&n,&m) != 2)
+  {
+    perror("read mtx size line");
+    throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
+  }
+
+  rhs = Vector(n,n,nullptr);
+
+  VectorWriter vector_writer(rhs);
+
+  for(int i = 0;i < n;++i)
+  {
+    double val = 0;
+    if(sscanf(reader.line(),"%lg\n",&val) != 1)
+    {
+      perror("read mtx line");
+      throw FatalErrorException(__PRETTY_FUNCTION__,"IOError");
+    }
+
+    vector_writer[i] = val;
+  }
+}
+
+MatrixMarketSystemReader::MatrixMarketSystemReader(std::string const& filename)
+: m_filename(filename)
+{
+}
+
+MatrixMarketSystemReader::~MatrixMarketSystemReader() = default;
+
+void MatrixMarketSystemReader::read(Matrix& A)
+{
+  FILE* fdes = fopen(m_filename.c_str(),"r");
+
+  if(fdes == nullptr)
+  {
+    perror(m_filename.c_str());
+    throw FatalErrorException(__PRETTY_FUNCTION__);
+  }
+
+  StreamFILEReader reader(fdes);
+  loadMMMatrixFromReader<StreamFILEReader>(A,reader);
+
+  if(fclose(fdes)!=0)
+  {
+    perror(m_filename.c_str());
+    throw FatalErrorException(__PRETTY_FUNCTION__);
+  }
+}
+
+void MatrixMarketSystemReader::read(Vector& rhs)
+{
+  FILE* fdes = fopen(m_filename.c_str(),"r");
+
+  if(fdes == nullptr)
+  {
+    perror(m_filename.c_str());
+    throw FatalErrorException(__PRETTY_FUNCTION__);
+  }
+
+  StreamFILEReader reader(fdes);
+  loadMMRhsFromReader<StreamFILEReader>(rhs,reader);
+
+  if(fclose(fdes)!=0)
+  {
+    perror(m_filename.c_str());
+    throw FatalErrorException(__PRETTY_FUNCTION__);
+  }
+}
+
+} /* namespace Alien */

--- a/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.h
+++ b/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.h
@@ -29,12 +29,15 @@ namespace Alien
 {
 class Matrix;
 class Vector;
-struct Exporter;
 
 class ALIEN_REFSEMANTIC_EXPORT MatrixMarketSystemReader
 {
  public:
-  MatrixMarketSystemReader(std::string const& filename);
+  MatrixMarketSystemReader() = delete;
+  MatrixMarketSystemReader(MatrixMarketSystemReader const&) = delete;
+  MatrixMarketSystemReader(MatrixMarketSystemReader&&) = delete;
+
+  explicit MatrixMarketSystemReader(std::string const& filename);
   virtual ~MatrixMarketSystemReader();
 
   void read(Matrix& A);

--- a/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.h
+++ b/src/refsemantic/alien/ref/import_export/MatrixMarketSystemReader.h
@@ -18,10 +18,30 @@
 
 #pragma once
 
-#include <alien/AlienConfig.h>
+#include <map>
 
-#include <alien/ref/import_export/SystemInfo.h>
-#include <alien/ref/import_export/SystemReader.h>
-#include <alien/ref/import_export/SystemWriter.h>
+#include "SystemInfo.h"
+#include <alien/ref/AlienRefSemanticPrecomp.h>
+#include <arccore/base/ArccoreGlobal.h>
+#include <arccore/message_passing/IMessagePassingMng.h>
 
-#include <alien/ref/import_export/MatrixMarketSystemReader.h>
+namespace Alien
+{
+class Matrix;
+class Vector;
+struct Exporter;
+
+class ALIEN_REFSEMANTIC_EXPORT MatrixMarketSystemReader
+{
+ public:
+  MatrixMarketSystemReader(std::string const& filename);
+  virtual ~MatrixMarketSystemReader();
+
+  void read(Matrix& A);
+  void read(Vector& rhs);
+
+ private:
+  std::string m_filename;
+};
+
+} // namespace Alien

--- a/src/refsemantic/alien/ref/import_export/Reader.h
+++ b/src/refsemantic/alien/ref/import_export/Reader.h
@@ -27,7 +27,9 @@
 #include <string>
 #include <fstream>
 #include <cstdio>
+#ifdef ALIEN_USE_LIBARCHIVE
 #include <archive.h>
+#endif
 
 namespace Alien
 {

--- a/src/refsemantic/alien/ref/import_export/Reader.h
+++ b/src/refsemantic/alien/ref/import_export/Reader.h
@@ -1,0 +1,220 @@
+/*
+* Copyright 2020 IFPEN-CEA
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
+
+#pragma once
+
+#include <alien/ref/data/scalar/Matrix.h>
+#include <alien/ref/data/scalar/Vector.h>
+#include <alien/ref/handlers/scalar/DirectMatrixBuilder.h>
+#include <alien/ref/handlers/scalar/VectorWriter.h>
+
+#include <vector>
+#include <string>
+#include <fstream>
+#include <cstdio>
+#include <archive.h>
+
+namespace Alien
+{
+
+class FStreamReader
+{
+ private:
+  std::fstream* m_file_stream = nullptr;
+  std::string m_line;
+
+ public:
+  FStreamReader() = delete;
+  FStreamReader(FStreamReader const&) = delete;
+  FStreamReader& operator=(FStreamReader const&) = delete;
+
+  explicit FStreamReader(std::fstream* fdes)
+  : m_file_stream(fdes)
+  {}
+
+  const char* line()
+  {
+    std::getline(*m_file_stream, m_line);
+
+    return m_line.c_str();
+  }
+
+  const char* currentLine() const
+  {
+    return m_line.c_str();
+  }
+};
+
+class LibArchiveReader
+{
+ private:
+  const std::size_t m_buffer_size = 1024;
+
+  archive* m_archive = nullptr;
+  std::string m_line;
+  std::vector<char> m_buffer;
+  std::size_t m_pos = 0;
+
+ public:
+  LibArchiveReader() = delete;
+  LibArchiveReader(const LibArchiveReader&) = delete;
+  LibArchiveReader& operator=(const LibArchiveReader&) = delete;
+
+  LibArchiveReader(archive *archive)
+  :
+  m_archive(archive),
+  m_buffer(m_buffer_size,0)
+  {
+    m_line.reserve(m_buffer_size);
+  }
+
+  const char* line()
+  {
+    la_ssize_t r = 1;
+
+    m_line.resize(0);
+
+    if(m_pos == 0)
+    {
+      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
+    }
+
+    while(r > 0)
+    {
+      for(auto i = m_pos;i < m_buffer_size;++i)
+      {
+        m_line.push_back(m_buffer[i]);
+        if(m_buffer[i] == '\n')
+        {
+          m_pos = i + 1;
+          //std::cout << m_line;
+          return m_line.c_str();
+        }
+      }
+      // end of line is not found so read next buffer;
+      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
+      m_pos = 0;
+    }
+
+    // end of file reached
+    return m_line.c_str();
+  }
+
+  const char* currentLine() const
+  {
+    return m_line.c_str();
+  }
+};
+
+template <typename ReaderT>
+bool readMMHeaderFromReader(const std::string& mm_type, ReaderT& reader)
+{
+  // check header
+  char param1[32];
+  char param2[32];
+  char param3[32];
+  char param4[32];
+
+  // TODO: use methods that directly read from std::string
+  if (sscanf(reader.line(), "%%%%MatrixMarket %31s %31s %31s %31s", param1, param2, param3, param4) != 4) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Matrix market wrong header");
+  }
+  if (std::string(param1) != std::string("matrix")) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Matrix market wrong header 1");
+  }
+  if (std::string(param2) != mm_type) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Matrix market wrong header 2");
+  }
+  if (std::string(param3) != std::string("real")) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Matrix market wrong header 3");
+  }
+
+  // skip comments
+  while (reader.line()[0] == '%');
+
+  return std::string(param4) == std::string("symmetric");
+}
+
+template <typename ReaderT>
+void loadMMMatrixFromReader(Matrix& A, ReaderT& reader)
+{
+  bool is_symmetric = readMMHeaderFromReader("coordinate", reader);
+
+  // first non comment line is: n m nnz
+  int n, m, nnz;
+  if (sscanf(reader.currentLine(), "%d %d %d", &n, &m, &nnz) != 3) {
+    perror("read mtx size line");
+    throw FatalErrorException(__PRETTY_FUNCTION__, "IOError");
+  }
+
+  A = Matrix(n, m, n, nullptr);
+
+  DirectMatrixOptions::SymmetricFlag sym_flag = is_symmetric ? DirectMatrixOptions::eSymmetric : DirectMatrixOptions::eUnSymmetric;
+
+  DirectMatrixBuilder matrix_builder(A, DirectMatrixOptions::eResetAllocation, sym_flag);
+  matrix_builder.allocate();
+
+  for (int i = 0; i < nnz; ++i) {
+    int li = 0;
+    int ci = 0;
+    double val = 0;
+
+    if (sscanf(reader.line(), "%d %d %lg\n", &li, &ci, &val) != 3) {
+      perror("read mtx line");
+      throw FatalErrorException(__PRETTY_FUNCTION__, "IOError");
+    }
+    li--;
+    ci--;
+
+    matrix_builder.addData(li, ci, val);
+  }
+}
+
+template <typename ReaderT>
+void loadMMRhsFromReader(Vector& rhs, ReaderT& reader)
+{
+  readMMHeaderFromReader("array", reader);
+
+  // first non comment line is: n m
+  int n, m;
+  if (sscanf(reader.currentLine(), "%d %d", &n, &m) != 2) {
+    perror("read mtx size line");
+    throw FatalErrorException(__PRETTY_FUNCTION__, "IOError");
+  }
+
+  if (m > 1) // does not allow more than one vector
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "More than one vector not allowed");
+  }
+
+  rhs = Vector(n, n, nullptr);
+
+  VectorWriter vector_writer(rhs);
+
+  for (int i = 0; i < n; ++i) {
+    double val = 0;
+    if (sscanf(reader.line(), "%lg\n", &val) != 1) {
+      perror("read mtx line");
+      throw FatalErrorException(__PRETTY_FUNCTION__, "IOError");
+    }
+
+    vector_writer[i] = val;
+  }
+}
+
+}

--- a/src/refsemantic/alien/ref/import_export/Reader.h
+++ b/src/refsemantic/alien/ref/import_export/Reader.h
@@ -75,10 +75,9 @@ class LibArchiveReader
   LibArchiveReader(const LibArchiveReader&) = delete;
   LibArchiveReader& operator=(const LibArchiveReader&) = delete;
 
-  LibArchiveReader(archive *archive)
-  :
-  m_archive(archive),
-  m_buffer(m_buffer_size,0)
+  LibArchiveReader(archive* archive)
+  : m_archive(archive)
+  , m_buffer(m_buffer_size, 0)
   {
     m_line.reserve(m_buffer_size);
   }
@@ -89,25 +88,21 @@ class LibArchiveReader
 
     m_line.resize(0);
 
-    if(m_pos == 0)
-    {
-      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
+    if (m_pos == 0) {
+      r = archive_read_data(m_archive, m_buffer.data(), m_buffer.size());
     }
 
-    while(r > 0)
-    {
-      for(auto i = m_pos;i < m_buffer_size;++i)
-      {
+    while (r > 0) {
+      for (auto i = m_pos; i < m_buffer_size; ++i) {
         m_line.push_back(m_buffer[i]);
-        if(m_buffer[i] == '\n')
-        {
+        if (m_buffer[i] == '\n') {
           m_pos = i + 1;
           //std::cout << m_line;
           return m_line.c_str();
         }
       }
       // end of line is not found so read next buffer;
-      r = archive_read_data(m_archive,m_buffer.data(),m_buffer.size());
+      r = archive_read_data(m_archive, m_buffer.data(), m_buffer.size());
       m_pos = 0;
     }
 
@@ -145,7 +140,8 @@ bool readMMHeaderFromReader(const std::string& mm_type, ReaderT& reader)
   }
 
   // skip comments
-  while (reader.line()[0] == '%');
+  while (reader.line()[0] == '%')
+    ;
 
   return std::string(param4) == std::string("symmetric");
 }
@@ -217,4 +213,4 @@ void loadMMRhsFromReader(Vector& rhs, ReaderT& reader)
   }
 }
 
-}
+} // namespace Alien

--- a/src/refsemantic/alien/ref/import_export/Reader.h
+++ b/src/refsemantic/alien/ref/import_export/Reader.h
@@ -60,6 +60,7 @@ class FStreamReader
   }
 };
 
+#ifdef ALIEN_USE_LIBARCHIVE
 class LibArchiveReader
 {
  private:
@@ -115,6 +116,7 @@ class LibArchiveReader
     return m_line.c_str();
   }
 };
+#endif
 
 template <typename ReaderT>
 bool readMMHeaderFromReader(const std::string& mm_type, ReaderT& reader)

--- a/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
+++ b/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
@@ -36,49 +36,42 @@ void SuiteSparseArchiveSystemReader::read(Matrix& A)
   archive_read_support_filter_gzip(m_archive);
   archive_read_support_format_tar(m_archive);
 
-  auto r = archive_read_open_filename(m_archive,m_filename.c_str(),10240);
-  if(r != ARCHIVE_OK)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Open archive " + m_filename);
+  auto r = archive_read_open_filename(m_archive, m_filename.c_str(), 10240);
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Open archive " + m_filename);
   }
 
   // look for matrix in archive
   bool matrix_found = false;
   archive_entry* entry = nullptr;
   auto pos = m_filename.find_last_of('/');
-  std::string matrix_name(m_filename,pos+1,m_filename.size()-pos-1-7);  // .tar.gz
+  std::string matrix_name(m_filename, pos + 1, m_filename.size() - pos - 1 - 7); // .tar.gz
 
-  while(archive_read_next_header(m_archive,&entry) == ARCHIVE_OK)
-  {
+  while (archive_read_next_header(m_archive, &entry) == ARCHIVE_OK) {
     //std::cout << "entry name :" << archive_entry_pathname(entry) << "\n";
-    if(archive_entry_pathname(entry) == std::string(matrix_name + "/" + matrix_name + ".mtx"))
-    {
+    if (archive_entry_pathname(entry) == std::string(matrix_name + "/" + matrix_name + ".mtx")) {
       matrix_found = true;
       break;
     }
     archive_read_data_skip(m_archive);
   }
 
-  if(!matrix_found)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix not found in " + m_filename);
+  if (!matrix_found) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Matrix not found in " + m_filename);
   }
 
   LibArchiveReader reader(m_archive);
   loadMMMatrixFromReader<LibArchiveReader>(A, reader);
 
   r = archive_read_close(m_archive);
-  if(r != ARCHIVE_OK)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Close archive " + m_filename);
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Close archive " + m_filename);
   }
 
   r = archive_free(m_archive);
-  if(r != ARCHIVE_OK)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Free archive");
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Free archive");
   }
-
 }
 
 void SuiteSparseArchiveSystemReader::read(Vector& rhs)
@@ -113,15 +106,13 @@ void SuiteSparseArchiveSystemReader::read(Vector& rhs)
   }
 
   r = archive_read_close(m_archive);
-  if(r != ARCHIVE_OK)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Close archive " + m_filename);
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Close archive " + m_filename);
   }
 
   r = archive_free(m_archive);
-  if(r != ARCHIVE_OK)
-  {
-    throw FatalErrorException(__PRETTY_FUNCTION__,"Free archive");
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Free archive");
   }
 }
 

--- a/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
+++ b/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.cc
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 IFPEN-CEA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <alien/ref/import_export/SuiteSparseArchiveSystemReader.h>
+#include <alien/ref/import_export/Reader.h>
+
+#include <archive_entry.h>
+
+namespace Alien
+{
+
+SuiteSparseArchiveSystemReader::SuiteSparseArchiveSystemReader(std::string const& filename)
+: m_filename(filename)
+{}
+
+SuiteSparseArchiveSystemReader::~SuiteSparseArchiveSystemReader() = default;
+
+void SuiteSparseArchiveSystemReader::read(Matrix& A)
+{
+  m_archive = archive_read_new();
+  archive_read_support_filter_gzip(m_archive);
+  archive_read_support_format_tar(m_archive);
+
+  auto r = archive_read_open_filename(m_archive,m_filename.c_str(),10240);
+  if(r != ARCHIVE_OK)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Open archive " + m_filename);
+  }
+
+  // look for matrix in archive
+  bool matrix_found = false;
+  archive_entry* entry = nullptr;
+  auto pos = m_filename.find_last_of('/');
+  std::string matrix_name(m_filename,pos+1,m_filename.size()-pos-1-7);  // .tar.gz
+
+  while(archive_read_next_header(m_archive,&entry) == ARCHIVE_OK)
+  {
+    //std::cout << "entry name :" << archive_entry_pathname(entry) << "\n";
+    if(archive_entry_pathname(entry) == std::string(matrix_name + "/" + matrix_name + ".mtx"))
+    {
+      matrix_found = true;
+      break;
+    }
+    archive_read_data_skip(m_archive);
+  }
+
+  if(!matrix_found)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Matrix not found in " + m_filename);
+  }
+
+  LibArchiveReader reader(m_archive);
+  loadMMMatrixFromReader<LibArchiveReader>(A, reader);
+
+  r = archive_read_close(m_archive);
+  if(r != ARCHIVE_OK)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Close archive " + m_filename);
+  }
+
+  r = archive_free(m_archive);
+  if(r != ARCHIVE_OK)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Free archive");
+  }
+
+}
+
+void SuiteSparseArchiveSystemReader::read(Vector& rhs)
+{
+  m_archive = archive_read_new();
+  archive_read_support_filter_gzip(m_archive);
+  archive_read_support_format_tar(m_archive);
+
+  auto r = archive_read_open_filename(m_archive, m_filename.c_str(), 10240);
+  if (r != ARCHIVE_OK) {
+    throw FatalErrorException(__PRETTY_FUNCTION__, "Open archive " + m_filename);
+  }
+
+  bool vector_found = false;
+  archive_entry* entry = nullptr;
+  auto pos = m_filename.find_last_of('/');
+  std::string matrix_name(m_filename, pos + 1, m_filename.size() - pos - 1 - 7); // .tar.gz
+
+  while (archive_read_next_header(m_archive, &entry) == ARCHIVE_OK) {
+    //std::cout << "entry name :" << archive_entry_pathname(entry) << "\n";
+    if (archive_entry_pathname(entry) == std::string(matrix_name + "/" + matrix_name + "_b.mtx")) {
+      vector_found = true;
+      break;
+    }
+    archive_read_data_skip(m_archive);
+  }
+
+  if (vector_found) // vector is not always present
+  {
+    LibArchiveReader reader(m_archive);
+    loadMMRhsFromReader<LibArchiveReader>(rhs, reader);
+  }
+
+  r = archive_read_close(m_archive);
+  if(r != ARCHIVE_OK)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Close archive " + m_filename);
+  }
+
+  r = archive_free(m_archive);
+  if(r != ARCHIVE_OK)
+  {
+    throw FatalErrorException(__PRETTY_FUNCTION__,"Free archive");
+  }
+}
+
+} /* namespace Alien */

--- a/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.h
+++ b/src/refsemantic/alien/ref/import_export/SuiteSparseArchiveSystemReader.h
@@ -22,27 +22,29 @@
 #include <arccore/base/ArccoreGlobal.h>
 
 #include <string>
+#include <archive.h>
 
 namespace Alien
 {
 class Matrix;
 class Vector;
 
-class ALIEN_REFSEMANTIC_EXPORT MatrixMarketSystemReader
+class ALIEN_REFSEMANTIC_EXPORT SuiteSparseArchiveSystemReader
 {
  public:
-  MatrixMarketSystemReader() = delete;
-  MatrixMarketSystemReader(MatrixMarketSystemReader const&) = delete;
-  MatrixMarketSystemReader& operator=(MatrixMarketSystemReader const&) = delete;
+  SuiteSparseArchiveSystemReader() = delete;
+  SuiteSparseArchiveSystemReader(SuiteSparseArchiveSystemReader const&) = delete;
+  SuiteSparseArchiveSystemReader& operator=(SuiteSparseArchiveSystemReader const&) = delete;
 
-  explicit MatrixMarketSystemReader(std::string const& filename);
-  virtual ~MatrixMarketSystemReader();
+  explicit SuiteSparseArchiveSystemReader(std::string const& filename);
+  virtual ~SuiteSparseArchiveSystemReader();
 
   void read(Matrix& A);
   void read(Vector& rhs);
 
  private:
   std::string m_filename;
+  archive* m_archive = nullptr;
 };
 
 } // namespace Alien

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -15,11 +15,13 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include <fstream>
 
 #include <gtest/gtest.h>
 
 #include <alien/ref/AlienImportExport.h>
 #include <alien/ref/AlienRefSemantic.h>
+#include <alien/kernels/simple_csr/SimpleCSRBackEnd.h>
 
 #include <Environment.h>
 
@@ -146,6 +148,88 @@ TEST(TestImportExport, ExportSystem)
 
 TEST(TestImportExport,ImportMatrixMarketMatrix)
 {
+  const std::string mat =
+  "%%MatrixMarket matrix coordinate real general\n"
+  "%-------------------------------------------------------------------------------\n"
+  "% UF Sparse Matrix Collection, Tim Davis\n"
+  "% http://www.cise.ufl.edu/research/sparse/matrices/vanHeukelum/cage4\n"
+  "% name: vanHeukelum/cage4\n"
+  "% [DNA electrophoresis, 4 monomers in polymer. A. van Heukelum, Utrecht U.]\n"
+  "% id: 905\n"
+  "% date: 2003\n"
+  "% author: A. van Heukelum\n"
+  "% ed: T. Davis\n"
+  "% fields: title A name id date author ed kind\n"
+  "% kind: directed weighted graph\n"
+  "%-------------------------------------------------------------------------------\n"
+  "9 9 49\n"
+  "1 1 .75\n"
+  "2 1 .075027667114587\n"
+  "4 1 .0916389995520797\n"
+  "5 1 .0375138335572935\n"
+  "8 1 .0458194997760398\n"
+  "1 2 .137458499328119\n"
+  "2 2 .687569167786467\n"
+  "3 2 .0916389995520797\n"
+  "5 2 .0375138335572935\n"
+  "6 2 .0458194997760398\n"
+  "2 3 .112541500671881\n"
+  "3 3 .666666666666667\n"
+  "4 3 .13745849932812\n"
+  "6 3 .0458194997760398\n"
+  "7 3 .0375138335572935\n"
+  "1 4 .112541500671881\n"
+  "3 4 .075027667114587\n"
+  "4 4 .729097498880199\n"
+  "7 4 .0375138335572935\n"
+  "8 4 .0458194997760398\n"
+  "1 5 .137458499328119\n"
+  "2 5 .075027667114587\n"
+  "5 5 .537513833557293\n"
+  "6 5 .075027667114587\n"
+  "7 5 .0916389995520797\n"
+  "9 5 .0833333333333333\n"
+  "2 6 .112541500671881\n"
+  "3 6 .0916389995520797\n"
+  "5 6 .13745849932812\n"
+  "6 6 .445874834005214\n"
+  "8 6 .13745849932812\n"
+  "9 6 .075027667114587\n"
+  "3 7 .075027667114587\n"
+  "4 7 .13745849932812\n"
+  "5 7 .112541500671881\n"
+  "7 7 .470791832661453\n"
+  "8 7 .112541500671881\n"
+  "9 7 .0916389995520797\n"
+  "1 8 .112541500671881\n"
+  "4 8 .0916389995520797\n"
+  "6 8 .075027667114587\n"
+  "7 8 .0916389995520797\n"
+  "8 8 .54581949977604\n"
+  "9 8 .0833333333333333\n"
+  "5 9 .25\n"
+  "6 9 .150055334229174\n"
+  "7 9 .183277999104159\n"
+  "8 9 .25\n"
+  "9 9 .166666666666667\n";
+
+  {
+    std::fstream matrix_file_stream("cage4.mtx",std::ios_base::out);
+    matrix_file_stream << mat;
+  }
+
+  Alien::Matrix A;
+
+  Alien::MatrixMarketSystemReader reader("cage4.mtx");
+
+  reader.read(A);
+
+  ASSERT_EQ(9,A.rowSpace().size());
+  ASSERT_EQ(9,A.rowSpace().size());
+
+  const auto& A_csr = A.impl()->get<Alien::BackEnd::tag::simplecsr>();
+
+  ASSERT_EQ(49,A_csr.getProfile().getNElems());
 
 }
 

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -225,7 +225,7 @@ TEST(TestImportExport,ImportMatrixMarketMatrix)
   reader.read(A);
 
   ASSERT_EQ(9,A.rowSpace().size());
-  ASSERT_EQ(9,A.rowSpace().size());
+  ASSERT_EQ(9,A.colSpace().size());
 
   const auto& A_csr = A.impl()->get<Alien::BackEnd::tag::simplecsr>();
 
@@ -235,5 +235,33 @@ TEST(TestImportExport,ImportMatrixMarketMatrix)
 
 TEST(TestImportExport,ImportMatrixMarketRhs)
 {
+  const std::string rhs =
+  "%%MatrixMarket matrix array real general\n"
+  "%-------------------------------------------------------------------------------\n"
+  "% Fake rhs for test\n"
+  "%-------------------------------------------------------------------------------\n"
+  "9 1\n"
+  ".75\n"
+  ".075027667114587\n"
+  ".0916389995520797\n"
+  ".0375138335572935\n"
+  ".0458194997760398\n"
+  ".137458499328119\n"
+  ".687569167786467\n"
+  ".0916389995520797\n"
+  ".0375138335572935\n";
+
+  {
+    std::fstream rhs_file_stream("vec_b.mtx",std::ios_base::out);
+    rhs_file_stream << rhs;
+  }
+
+  Alien::Vector vec;
+
+  Alien::MatrixMarketSystemReader reader("vec_b.mtx");
+
+  reader.read(vec);
+
+  ASSERT_EQ(9,vec.space().size());
 
 }

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -143,3 +143,13 @@ TEST(TestImportExport, ExportSystem)
     writer.dump(A, b, x, sol_info);
   }
 }
+
+TEST(TestImportExport,ImportMatrixMarketMatrix)
+{
+
+}
+
+TEST(TestImportExport,ImportMatrixMarketRhs)
+{
+
+}

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -148,199 +148,205 @@ TEST(TestImportExport, ExportSystem)
 
 TEST(TestImportExport,ImportMatrixMarketMatrix)
 {
-  const std::string mat =
-  "%%MatrixMarket matrix coordinate real general\n"
-  "%-------------------------------------------------------------------------------\n"
-  "% UF Sparse Matrix Collection, Tim Davis\n"
-  "% http://www.cise.ufl.edu/research/sparse/matrices/vanHeukelum/cage4\n"
-  "% name: vanHeukelum/cage4\n"
-  "% [DNA electrophoresis, 4 monomers in polymer. A. van Heukelum, Utrecht U.]\n"
-  "% id: 905\n"
-  "% date: 2003\n"
-  "% author: A. van Heukelum\n"
-  "% ed: T. Davis\n"
-  "% fields: title A name id date author ed kind\n"
-  "% kind: directed weighted graph\n"
-  "%-------------------------------------------------------------------------------\n"
-  "9 9 49\n"
-  "1 1 .75\n"
-  "2 1 .075027667114587\n"
-  "4 1 .0916389995520797\n"
-  "5 1 .0375138335572935\n"
-  "8 1 .0458194997760398\n"
-  "1 2 .137458499328119\n"
-  "2 2 .687569167786467\n"
-  "3 2 .0916389995520797\n"
-  "5 2 .0375138335572935\n"
-  "6 2 .0458194997760398\n"
-  "2 3 .112541500671881\n"
-  "3 3 .666666666666667\n"
-  "4 3 .13745849932812\n"
-  "6 3 .0458194997760398\n"
-  "7 3 .0375138335572935\n"
-  "1 4 .112541500671881\n"
-  "3 4 .075027667114587\n"
-  "4 4 .729097498880199\n"
-  "7 4 .0375138335572935\n"
-  "8 4 .0458194997760398\n"
-  "1 5 .137458499328119\n"
-  "2 5 .075027667114587\n"
-  "5 5 .537513833557293\n"
-  "6 5 .075027667114587\n"
-  "7 5 .0916389995520797\n"
-  "9 5 .0833333333333333\n"
-  "2 6 .112541500671881\n"
-  "3 6 .0916389995520797\n"
-  "5 6 .13745849932812\n"
-  "6 6 .445874834005214\n"
-  "8 6 .13745849932812\n"
-  "9 6 .075027667114587\n"
-  "3 7 .075027667114587\n"
-  "4 7 .13745849932812\n"
-  "5 7 .112541500671881\n"
-  "7 7 .470791832661453\n"
-  "8 7 .112541500671881\n"
-  "9 7 .0916389995520797\n"
-  "1 8 .112541500671881\n"
-  "4 8 .0916389995520797\n"
-  "6 8 .075027667114587\n"
-  "7 8 .0916389995520797\n"
-  "8 8 .54581949977604\n"
-  "9 8 .0833333333333333\n"
-  "5 9 .25\n"
-  "6 9 .150055334229174\n"
-  "7 9 .183277999104159\n"
-  "8 9 .25\n"
-  "9 9 .166666666666667\n";
+  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+    const std::string mat =
+    "%%MatrixMarket matrix coordinate real general\n"
+    "%-------------------------------------------------------------------------------\n"
+    "% UF Sparse Matrix Collection, Tim Davis\n"
+    "% http://www.cise.ufl.edu/research/sparse/matrices/vanHeukelum/cage4\n"
+    "% name: vanHeukelum/cage4\n"
+    "% [DNA electrophoresis, 4 monomers in polymer. A. van Heukelum, Utrecht U.]\n"
+    "% id: 905\n"
+    "% date: 2003\n"
+    "% author: A. van Heukelum\n"
+    "% ed: T. Davis\n"
+    "% fields: title A name id date author ed kind\n"
+    "% kind: directed weighted graph\n"
+    "%-------------------------------------------------------------------------------\n"
+    "9 9 49\n"
+    "1 1 .75\n"
+    "2 1 .075027667114587\n"
+    "4 1 .0916389995520797\n"
+    "5 1 .0375138335572935\n"
+    "8 1 .0458194997760398\n"
+    "1 2 .137458499328119\n"
+    "2 2 .687569167786467\n"
+    "3 2 .0916389995520797\n"
+    "5 2 .0375138335572935\n"
+    "6 2 .0458194997760398\n"
+    "2 3 .112541500671881\n"
+    "3 3 .666666666666667\n"
+    "4 3 .13745849932812\n"
+    "6 3 .0458194997760398\n"
+    "7 3 .0375138335572935\n"
+    "1 4 .112541500671881\n"
+    "3 4 .075027667114587\n"
+    "4 4 .729097498880199\n"
+    "7 4 .0375138335572935\n"
+    "8 4 .0458194997760398\n"
+    "1 5 .137458499328119\n"
+    "2 5 .075027667114587\n"
+    "5 5 .537513833557293\n"
+    "6 5 .075027667114587\n"
+    "7 5 .0916389995520797\n"
+    "9 5 .0833333333333333\n"
+    "2 6 .112541500671881\n"
+    "3 6 .0916389995520797\n"
+    "5 6 .13745849932812\n"
+    "6 6 .445874834005214\n"
+    "8 6 .13745849932812\n"
+    "9 6 .075027667114587\n"
+    "3 7 .075027667114587\n"
+    "4 7 .13745849932812\n"
+    "5 7 .112541500671881\n"
+    "7 7 .470791832661453\n"
+    "8 7 .112541500671881\n"
+    "9 7 .0916389995520797\n"
+    "1 8 .112541500671881\n"
+    "4 8 .0916389995520797\n"
+    "6 8 .075027667114587\n"
+    "7 8 .0916389995520797\n"
+    "8 8 .54581949977604\n"
+    "9 8 .0833333333333333\n"
+    "5 9 .25\n"
+    "6 9 .150055334229174\n"
+    "7 9 .183277999104159\n"
+    "8 9 .25\n"
+    "9 9 .166666666666667\n";
 
-  {
-    std::fstream matrix_file_stream("cage4.mtx",std::ios_base::out);
-    matrix_file_stream << mat;
+    {
+      std::fstream matrix_file_stream("cage4.mtx", std::ios_base::out);
+      matrix_file_stream << mat;
+    }
+
+    Alien::Matrix A;
+
+    Alien::MatrixMarketSystemReader reader("cage4.mtx");
+
+    reader.read(A);
+
+    ASSERT_EQ(9, A.rowSpace().size());
+    ASSERT_EQ(9, A.colSpace().size());
+
+    const auto& A_csr = A.impl()->get<Alien::BackEnd::tag::simplecsr>();
+
+    ASSERT_EQ(49, A_csr.getProfile().getNElems());
+
+    system("rm cage4.mtx");
   }
-
-  Alien::Matrix A;
-
-  Alien::MatrixMarketSystemReader reader("cage4.mtx");
-
-  reader.read(A);
-
-  ASSERT_EQ(9,A.rowSpace().size());
-  ASSERT_EQ(9,A.colSpace().size());
-
-  const auto& A_csr = A.impl()->get<Alien::BackEnd::tag::simplecsr>();
-
-  ASSERT_EQ(49,A_csr.getProfile().getNElems());
-
-  system("rm cage4.mtx");
 }
 
 TEST(TestImportExport,ImportMatrixMarketRhs)
 {
-  const std::string rhs =
-  "%%MatrixMarket matrix array real general\n"
-  "%-------------------------------------------------------------------------------\n"
-  "% Fake rhs for test\n"
-  "%-------------------------------------------------------------------------------\n"
-  "9 1\n"
-  ".75\n"
-  ".075027667114587\n"
-  ".0916389995520797\n"
-  ".0375138335572935\n"
-  ".0458194997760398\n"
-  ".137458499328119\n"
-  ".687569167786467\n"
-  ".0916389995520797\n"
-  ".0375138335572935\n";
+  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+    const std::string rhs =
+    "%%MatrixMarket matrix array real general\n"
+    "%-------------------------------------------------------------------------------\n"
+    "% Fake rhs for test\n"
+    "%-------------------------------------------------------------------------------\n"
+    "9 1\n"
+    ".75\n"
+    ".075027667114587\n"
+    ".0916389995520797\n"
+    ".0375138335572935\n"
+    ".0458194997760398\n"
+    ".137458499328119\n"
+    ".687569167786467\n"
+    ".0916389995520797\n"
+    ".0375138335572935\n";
 
-  {
-    std::fstream rhs_file_stream("vec_b.mtx",std::ios_base::out);
-    rhs_file_stream << rhs;
+    {
+      std::fstream rhs_file_stream("vec_b.mtx", std::ios_base::out);
+      rhs_file_stream << rhs;
+    }
+
+    Alien::Vector vec;
+
+    Alien::MatrixMarketSystemReader reader("vec_b.mtx");
+
+    reader.read(vec);
+
+    ASSERT_EQ(9, vec.space().size());
+
+    system("rm vec_b.mtx");
   }
-
-  Alien::Vector vec;
-
-  Alien::MatrixMarketSystemReader reader("vec_b.mtx");
-
-  reader.read(vec);
-
-  ASSERT_EQ(9,vec.space().size());
-
-  system("rm vec_b.mtx");
 }
 
 TEST(TestImportExport,ImportSuiteSparseArchive)
 {
-  const std::string mat =
-  "%%MatrixMarket matrix coordinate real general\n"
-  "%-------------------------------------------------------------------------------\n"
-  "% UF Sparse Matrix Collection, Tim Davis\n"
-  "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
-  "% name: Grund/b1_ss\n"
-  "% [Unsymmetric Matrix b1_ss, F. Grund, Dec 1994.]\n"
-  "% id: 449\n"
-  "% date: 1997\n"
-  "% author: F. Grund\n"
-  "% ed: F. Grund\n"
-  "% fields: title A b name id date author ed kind\n"
-  "% kind: chemical process simulation problem\n"
-  "%-------------------------------------------------------------------------------\n"
-  "7 7 15\n"
-  "5 1 -.03599942\n"
-  "6 1 -.0176371\n"
-  "7 1 -.007721779\n"
-  "1 2 1\n"
-  "2 2 -1\n"
-  "1 3 1\n"
-  "3 3 -1\n"
-  "1 4 1\n"
-  "4 4 -1\n"
-  "2 5 .45\n"
-  "5 5 1\n"
-  "3 6 .1\n"
-  "6 6 1\n"
-  "4 7 .45\n"
-  "7 7 1\n";
+  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+    const std::string mat =
+    "%%MatrixMarket matrix coordinate real general\n"
+    "%-------------------------------------------------------------------------------\n"
+    "% UF Sparse Matrix Collection, Tim Davis\n"
+    "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
+    "% name: Grund/b1_ss\n"
+    "% [Unsymmetric Matrix b1_ss, F. Grund, Dec 1994.]\n"
+    "% id: 449\n"
+    "% date: 1997\n"
+    "% author: F. Grund\n"
+    "% ed: F. Grund\n"
+    "% fields: title A b name id date author ed kind\n"
+    "% kind: chemical process simulation problem\n"
+    "%-------------------------------------------------------------------------------\n"
+    "7 7 15\n"
+    "5 1 -.03599942\n"
+    "6 1 -.0176371\n"
+    "7 1 -.007721779\n"
+    "1 2 1\n"
+    "2 2 -1\n"
+    "1 3 1\n"
+    "3 3 -1\n"
+    "1 4 1\n"
+    "4 4 -1\n"
+    "2 5 .45\n"
+    "5 5 1\n"
+    "3 6 .1\n"
+    "6 6 1\n"
+    "4 7 .45\n"
+    "7 7 1\n";
 
-  const std::string rhs =
-  "%%MatrixMarket matrix array real general\n"
-  "%-------------------------------------------------------------------------------\n"
-  "% UF Sparse Matrix Collection, Tim Davis\n"
-  "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
-  "% name: Grund/b1_ss : b matrix\n"
-  "%-------------------------------------------------------------------------------\n"
-  "7 1\n"
-  "-.0001\n"
-  ".1167\n"
-  "-.2333\n"
-  ".1167\n"
-  "-.4993128\n"
-  ".3435885\n"
-  ".7467878\n";
+    const std::string rhs =
+    "%%MatrixMarket matrix array real general\n"
+    "%-------------------------------------------------------------------------------\n"
+    "% UF Sparse Matrix Collection, Tim Davis\n"
+    "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
+    "% name: Grund/b1_ss : b matrix\n"
+    "%-------------------------------------------------------------------------------\n"
+    "7 1\n"
+    "-.0001\n"
+    ".1167\n"
+    "-.2333\n"
+    ".1167\n"
+    "-.4993128\n"
+    ".3435885\n"
+    ".7467878\n";
 
-  system("mkdir b1_ss");
+    system("mkdir b1_ss");
+    system("pwd");
+    {
+      std::fstream mat_file_stream("b1_ss/b1_ss.mtx", std::ios_base::out);
+      mat_file_stream << mat;
+      std::fstream rhs_file_stream("b1_ss/b1_ss_b.mtx", std::ios_base::out);
+      rhs_file_stream << rhs;
+    }
 
-  {
-    std::fstream mat_file_stream("b1_ss/b1_ss.mtx", std::ios_base::out);
-    mat_file_stream << mat;
-    std::fstream rhs_file_stream("b1_ss/b1_ss_b.mtx", std::ios_base::out);
-    rhs_file_stream << rhs;
+    system("tar -zcf b1_ss.tar.gz b1_ss");
+    system("rm -r b1_ss");
+
+    Alien::SuiteSparseArchiveSystemReader archive_system_reader("b1_ss.tar.gz");
+
+    Alien::Matrix A;
+    Alien::Vector vec;
+
+    archive_system_reader.read(A);
+    archive_system_reader.read(vec);
+
+    ASSERT_EQ(7, A.rowSpace().size());
+    ASSERT_EQ(7, A.colSpace().size());
+
+    ASSERT_EQ(7, vec.space().size());
+
+    system("rm b1_ss.tar.gz");
   }
-
-  system("tar -zcf b1_ss.tar.gz b1_ss");
-  system("rm -r b1_ss");
-
-  Alien::SuiteSparseArchiveSystemReader archive_system_reader("b1_ss.tar.gz");
-
-  Alien::Matrix A;
-  Alien::Vector vec;
-
-  archive_system_reader.read(A);
-  archive_system_reader.read(vec);
-
-  ASSERT_EQ(7,A.rowSpace().size());
-  ASSERT_EQ(7,A.colSpace().size());
-
-  ASSERT_EQ(7,vec.space().size());
-
-  system("rm b1_ss.tar.gz");
 }

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -272,6 +272,7 @@ TEST(TestImportExport, ImportMatrixMarketRhs)
   }
 }
 
+#ifdef ALIEN_USE_LIBARCHIVE
 TEST(TestImportExport, ImportSuiteSparseArchive)
 {
   if (AlienTest::Environment::parallelMng()->commRank() == 0) {
@@ -351,3 +352,4 @@ TEST(TestImportExport, ImportSuiteSparseArchive)
     system("rm b1_ss.tar.gz");
   }
 }
+#endif

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -146,9 +146,9 @@ TEST(TestImportExport, ExportSystem)
   }
 }
 
-TEST(TestImportExport,ImportMatrixMarketMatrix)
+TEST(TestImportExport, ImportMatrixMarketMatrix)
 {
-  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+  if (AlienTest::Environment::parallelMng()->commRank() == 0) {
     const std::string mat =
     "%%MatrixMarket matrix coordinate real general\n"
     "%-------------------------------------------------------------------------------\n"
@@ -236,9 +236,9 @@ TEST(TestImportExport,ImportMatrixMarketMatrix)
   }
 }
 
-TEST(TestImportExport,ImportMatrixMarketRhs)
+TEST(TestImportExport, ImportMatrixMarketRhs)
 {
-  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+  if (AlienTest::Environment::parallelMng()->commRank() == 0) {
     const std::string rhs =
     "%%MatrixMarket matrix array real general\n"
     "%-------------------------------------------------------------------------------\n"
@@ -272,9 +272,9 @@ TEST(TestImportExport,ImportMatrixMarketRhs)
   }
 }
 
-TEST(TestImportExport,ImportSuiteSparseArchive)
+TEST(TestImportExport, ImportSuiteSparseArchive)
 {
-  if(AlienTest::Environment::parallelMng()->commRank()==0) {
+  if (AlienTest::Environment::parallelMng()->commRank() == 0) {
     const std::string mat =
     "%%MatrixMarket matrix coordinate real general\n"
     "%-------------------------------------------------------------------------------\n"
@@ -322,6 +322,7 @@ TEST(TestImportExport,ImportSuiteSparseArchive)
     ".3435885\n"
     ".7467878\n";
 
+    system("rm -rf b1_ss");
     system("mkdir b1_ss");
     system("pwd");
     {

--- a/src/refsemantic/tests/TestImportExport.cc
+++ b/src/refsemantic/tests/TestImportExport.cc
@@ -231,6 +231,7 @@ TEST(TestImportExport,ImportMatrixMarketMatrix)
 
   ASSERT_EQ(49,A_csr.getProfile().getNElems());
 
+  system("rm cage4.mtx");
 }
 
 TEST(TestImportExport,ImportMatrixMarketRhs)
@@ -264,4 +265,82 @@ TEST(TestImportExport,ImportMatrixMarketRhs)
 
   ASSERT_EQ(9,vec.space().size());
 
+  system("rm vec_b.mtx");
+}
+
+TEST(TestImportExport,ImportSuiteSparseArchive)
+{
+  const std::string mat =
+  "%%MatrixMarket matrix coordinate real general\n"
+  "%-------------------------------------------------------------------------------\n"
+  "% UF Sparse Matrix Collection, Tim Davis\n"
+  "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
+  "% name: Grund/b1_ss\n"
+  "% [Unsymmetric Matrix b1_ss, F. Grund, Dec 1994.]\n"
+  "% id: 449\n"
+  "% date: 1997\n"
+  "% author: F. Grund\n"
+  "% ed: F. Grund\n"
+  "% fields: title A b name id date author ed kind\n"
+  "% kind: chemical process simulation problem\n"
+  "%-------------------------------------------------------------------------------\n"
+  "7 7 15\n"
+  "5 1 -.03599942\n"
+  "6 1 -.0176371\n"
+  "7 1 -.007721779\n"
+  "1 2 1\n"
+  "2 2 -1\n"
+  "1 3 1\n"
+  "3 3 -1\n"
+  "1 4 1\n"
+  "4 4 -1\n"
+  "2 5 .45\n"
+  "5 5 1\n"
+  "3 6 .1\n"
+  "6 6 1\n"
+  "4 7 .45\n"
+  "7 7 1\n";
+
+  const std::string rhs =
+  "%%MatrixMarket matrix array real general\n"
+  "%-------------------------------------------------------------------------------\n"
+  "% UF Sparse Matrix Collection, Tim Davis\n"
+  "% http://www.cise.ufl.edu/research/sparse/matrices/Grund/b1_ss\n"
+  "% name: Grund/b1_ss : b matrix\n"
+  "%-------------------------------------------------------------------------------\n"
+  "7 1\n"
+  "-.0001\n"
+  ".1167\n"
+  "-.2333\n"
+  ".1167\n"
+  "-.4993128\n"
+  ".3435885\n"
+  ".7467878\n";
+
+  system("mkdir b1_ss");
+
+  {
+    std::fstream mat_file_stream("b1_ss/b1_ss.mtx", std::ios_base::out);
+    mat_file_stream << mat;
+    std::fstream rhs_file_stream("b1_ss/b1_ss_b.mtx", std::ios_base::out);
+    rhs_file_stream << rhs;
+  }
+
+  system("tar -zcf b1_ss.tar.gz b1_ss");
+  system("rm -r b1_ss");
+
+  Alien::SuiteSparseArchiveSystemReader archive_system_reader("b1_ss.tar.gz");
+
+  Alien::Matrix A;
+  Alien::Vector vec;
+
+  archive_system_reader.read(A);
+  archive_system_reader.read(vec);
+
+  ASSERT_EQ(7,A.rowSpace().size());
+  ASSERT_EQ(7,A.colSpace().size());
+
+  ASSERT_EQ(7,vec.space().size());
+
+  system("rm b1_ss.tar.gz");
 }


### PR DESCRIPTION
Add simple Matrix Market in ref api. The reader only  build a matrix on one process that can further be distributed with Matrix Redistributor.
Also add a reader that read directly in .tag.gz files we obtain from  Suite Sparse Matrix collection at http://sparse.tamu.edu/