### PR TITLE
Fixe Solver Statistics management regression. (#187)

### DIFF
--- a/plugins/ginkgo/src/ginkgo_linear_solver.h
+++ b/plugins/ginkgo/src/ginkgo_linear_solver.h
@@ -77,6 +77,7 @@ class InternalLinearSolver
   //! Etat du solveur
   const SolverStatus& getStatus() const override;
   const SolverStat& getSolverStat() const override { return m_stat; }
+  SolverStat& getSolverStat() override { return m_stat; }
 
   std::shared_ptr<ILinearAlgebra> algebra() const override;
 

--- a/plugins/hypre/src/hypre_linear_solver.h
+++ b/plugins/hypre/src/hypre_linear_solver.h
@@ -59,6 +59,8 @@ class InternalLinearSolver : public IInternalLinearSolver<Matrix, Vector>
 
   const SolverStat& getSolverStat() const final { return m_stat; }
 
+  SolverStat& getSolverStat() override { return m_stat; }
+
   std::shared_ptr<ILinearAlgebra> algebra() const final;
 
  private:

--- a/plugins/petsc/src/petsc_linear_solver.cpp
+++ b/plugins/petsc/src/petsc_linear_solver.cpp
@@ -68,6 +68,8 @@ class InternalLinearSolver
 
   const SolverStat& getSolverStat() const override { return m_stat; }
 
+  SolverStat& getSolverStat() override { return m_stat; }
+
   std::shared_ptr<ILinearAlgebra> algebra() const override;
 
  private:

--- a/plugins/trilinos/src/trilinos_linear_solver.h
+++ b/plugins/trilinos/src/trilinos_linear_solver.h
@@ -57,6 +57,8 @@ class InternalLinearSolver : public IInternalLinearSolver<Matrix, Vector>
 
   const SolverStat& getSolverStat() const { return m_stat; }
 
+  SolverStat& getSolverStat() override { return m_stat; }
+
   std::shared_ptr<ILinearAlgebra> algebra() const;
 
  private:

--- a/src/core/alien/core/backend/IInternalLinearSolverT.h
+++ b/src/core/alien/core/backend/IInternalLinearSolverT.h
@@ -98,6 +98,16 @@ class IInternalLinearSolver
   virtual SolverStat const& getSolverStat() const = 0;
 
   /*!
+   * \brief Get statistics on the solve phase
+   *
+   * Get statistics on the solver phase, such as iteration count, initialization time,
+   * solve time, etc.
+   *
+   * \return Solver statistics
+   */
+  virtual SolverStat& getSolverStat() = 0;
+
+  /*!
    * \brief Indicates if the kernel is parallel
    * \returns Parallel support capability
    */

--- a/src/core/alien/core/backend/LinearSolver.h
+++ b/src/core/alien/core/backend/LinearSolver.h
@@ -34,6 +34,7 @@
 
 #include <alien/expression/solver/ILinearSolver.h>
 
+#include <alien/expression/solver/SolverStater.h>
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -77,6 +78,7 @@ class LinearSolver : public ILinearSolver
   template <typename... T>
   LinearSolver(T... args)
   : m_solver(AlgebraTraits<Tag>::solver_factory(args...))
+  , m_stater(m_solver.get())
   {}
 
   //! Free resources
@@ -102,6 +104,7 @@ class LinearSolver : public ILinearSolver
    * \param[in] pm : new parallel mng
    */
   void updateParallelMng(Arccore::MessagePassing::IMessagePassingMng* pm);
+
   /*!
    * \brief Solve the linear system A * x = b
    * \param[in] A The matrix to invert
@@ -162,6 +165,7 @@ class LinearSolver : public ILinearSolver
  private:
   //! The linear solver kernel
   std::unique_ptr<KernelSolver> m_solver;
+  SolverStater<KernelSolver> m_stater;
 };
 
 /*---------------------------------------------------------------------------*/

--- a/src/core/alien/core/backend/LinearSolverT.h
+++ b/src/core/alien/core/backend/LinearSolverT.h
@@ -75,11 +75,14 @@ bool LinearSolver<Tag>::solve(const IMatrix& A, const IVector& b, IVector& x)
   else {
     m_solver->updateParallelMng(A.impl()->distribution().parallelMng());
   }
-  // m_solver->getSolverStat().startPrepareMeasure();
+
+  SolverStatSentry<KernelSolver> sentry(m_stater, BaseSolverStater::ePrepare);
   const auto& matrix = A.impl()->get<Tag>();
   const auto& rhs = b.impl()->get<Tag>();
   auto& sol = x.impl()->get<Tag>(true);
-  // m_solver->getSolverStat().stopPrepareMeasure();
+  sentry.release();
+
+  SolverStatSentry<KernelSolver> sentry2(m_stater, BaseSolverStater::eSolve);
   return m_solver->solve(matrix, rhs, sol);
 }
 
@@ -89,6 +92,7 @@ bool LinearSolver<Tag>::solve(const IMatrix& A, const IVector& b, IVector& x)
 template <class Tag>
 void LinearSolver<Tag>::init()
 {
+  SolverStatSentry<KernelSolver> sentry(m_stater, BaseSolverStater::eInit);
   m_solver->init();
 }
 

--- a/src/core/alien/expression/solver/SolverStat.cc
+++ b/src/core/alien/expression/solver/SolverStat.cc
@@ -32,6 +32,7 @@ namespace Alien
 {
 
 using namespace Arccore;
+
 /*---------------------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
 
@@ -81,6 +82,17 @@ SolverStat::SolverStat()
 {}
 
 /*---------------------------------------------------------------------------*/
+void SolverStat::reset()
+{
+  m_solve_count = 0;
+  m_iteration_count = 0;
+  m_last_iteration_count = 0;
+  m_initialization_time = m_initialization_cpu_time = 0;
+  m_prepare_time = m_prepare_cpu_time = 0;
+  m_last_prepare_time = m_last_prepare_cpu_time = 0;
+  m_solve_time = m_solve_cpu_time = 0;
+  m_last_solve_time = m_last_solve_cpu_time = 0;
+}
 
 Integer
 SolverStat::solveCount() const

--- a/src/core/alien/expression/solver/SolverStat.h
+++ b/src/core/alien/expression/solver/SolverStat.h
@@ -35,6 +35,7 @@ namespace Alien
 class ALIEN_EXPORT SolverStat
 {
  public:
+  template <typename SolverT> friend class SolverStater;
   /** Constructeur de la classe */
   SolverStat();
 
@@ -57,6 +58,8 @@ class ALIEN_EXPORT SolverStat
   Real lastSolveTime() const;
   Real lastSolveCpuTime() const;
 
+  void reset();
+
  public:
   void print(
   ITraceMng* traceMng, const SolverStatus& status, String title = String()) const;
@@ -78,7 +81,6 @@ class ALIEN_EXPORT SolverStat
 };
 
 /*---------------------------------------------------------------------------*/
-
 } // namespace Alien
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
* Fixe Solver Statistics management regression. Improve the management to reduce the impact on the API. Separation of Status and Stats structure from the Stater structure that computes and fill the Stat structure

* clang format correction

* fix clang-format

* clang-format

* fix export problem